### PR TITLE
Compatibility with PHP 5.4

### DIFF
--- a/src/Geocode.php
+++ b/src/Geocode.php
@@ -56,7 +56,8 @@ class Geocode extends Object
      */
     private function buildUrl(array $params)
     {
-        if (empty(ArrayHelper::getValue($params, 'format'))) {
+        $value = ArrayHelper::getValue($params, 'format');
+        if (empty($value)) {
             $params['format'] = $this->format;
         }
 


### PR DESCRIPTION
Note from documentation:
>Prior to PHP 5.5, empty() only supports variables; anything else will result in a parse error.